### PR TITLE
V10 load balanced

### DIFF
--- a/Our.Umbraco.MaintenanceMode/Composers/MaintenceModeComposer.cs
+++ b/Our.Umbraco.MaintenanceMode/Composers/MaintenceModeComposer.cs
@@ -1,10 +1,13 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 
 using Our.Umbraco.MaintenanceMode.Configurations;
+using Our.Umbraco.MaintenanceMode.Factories;
 using Our.Umbraco.MaintenanceMode.Interfaces;
+using Our.Umbraco.MaintenanceMode.NotificationHandlers.Application;
 using Our.Umbraco.MaintenanceMode.NotificationHandlers.Content;
 using Our.Umbraco.MaintenanceMode.NotificationHandlers.Media;
 using Our.Umbraco.MaintenanceMode.NotificationHandlers.ServerVariables;
+using Our.Umbraco.MaintenanceMode.Providers;
 using Our.Umbraco.MaintenanceMode.Services;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,6 +17,7 @@ using Umbraco.Cms.Core.Dashboards;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Our.Umbraco.MaintenanceMode.Composers
@@ -40,6 +44,9 @@ namespace Our.Umbraco.MaintenanceMode.Composers
 
 
             builder.Services.AddTransient<IBackofficeUserAccessor, BackofficeUserAccessor>();
+            builder.Services.AddSingleton<IStorageProviderFactory, StorageProviderFactory>();
+            builder.Services.AddSingleton<FileSystemStorageProvider>()
+                            .AddSingleton<IStorageProvider, FileSystemStorageProvider>(s => s.GetService<FileSystemStorageProvider>());
             builder.Services.AddUnique<IMaintenanceModeService, MaintenanceModeService>();
 
             builder.AddNotificationHandlers();

--- a/Our.Umbraco.MaintenanceMode/Composers/MaintenceModeComposer.cs
+++ b/Our.Umbraco.MaintenanceMode/Composers/MaintenceModeComposer.cs
@@ -17,7 +17,6 @@ using Umbraco.Cms.Core.Dashboards;
 using Umbraco.Cms.Core.DependencyInjection;
 using Umbraco.Cms.Core.Manifest;
 using Umbraco.Cms.Core.Notifications;
-using Umbraco.Cms.Core.Services;
 using Umbraco.Extensions;
 
 namespace Our.Umbraco.MaintenanceMode.Composers
@@ -42,11 +41,12 @@ namespace Our.Umbraco.MaintenanceMode.Composers
             builder.Services.Configure<MaintenanceModeSettings>
                 (builder.Config.GetSection("MaintenanceMode"));
 
-
             builder.Services.AddTransient<IBackofficeUserAccessor, BackofficeUserAccessor>();
             builder.Services.AddSingleton<IStorageProviderFactory, StorageProviderFactory>();
             builder.Services.AddSingleton<FileSystemStorageProvider>()
                             .AddSingleton<IStorageProvider, FileSystemStorageProvider>(s => s.GetService<FileSystemStorageProvider>());
+            builder.Services.AddSingleton<DatabaseStorageProvider>()
+                            .AddSingleton<IStorageProvider, DatabaseStorageProvider>(s => s.GetService<DatabaseStorageProvider>());
             builder.Services.AddUnique<IMaintenanceModeService, MaintenanceModeService>();
 
             builder.AddNotificationHandlers();
@@ -73,6 +73,8 @@ namespace Our.Umbraco.MaintenanceMode.Composers
                 .AddNotificationHandler<MediaMovingNotification, FreezeMediaMovingNotification>()
                 .AddNotificationHandler<MediaMovingToRecycleBinNotification, FreezeMediaMovingToRecycleBinNotification>()
                 .AddNotificationHandler<MediaSavingNotification, FreezeMediaSavingNotification>();
+
+            builder.AddNotificationHandler<UmbracoApplicationStartingNotification, UmbracoApplicationStartingHandler>();
         }
     }
 

--- a/Our.Umbraco.MaintenanceMode/Configurations/MaintenanceModeSettings.cs
+++ b/Our.Umbraco.MaintenanceMode/Configurations/MaintenanceModeSettings.cs
@@ -5,5 +5,6 @@
         public bool IsInMaintenanceMode { get; set; }
         public bool IsContentFrozen { get; set; }
         public StorageMode StorageMode { get; set; }
+        public int CacheSeconds { get; set; } = 30;
     }
 }

--- a/Our.Umbraco.MaintenanceMode/Configurations/MaintenanceModeSettings.cs
+++ b/Our.Umbraco.MaintenanceMode/Configurations/MaintenanceModeSettings.cs
@@ -4,5 +4,6 @@
     {
         public bool IsInMaintenanceMode { get; set; }
         public bool IsContentFrozen { get; set; }
+        public StorageMode StorageMode { get; set; }
     }
 }

--- a/Our.Umbraco.MaintenanceMode/Configurations/MaintenanceModeSettings.cs
+++ b/Our.Umbraco.MaintenanceMode/Configurations/MaintenanceModeSettings.cs
@@ -5,6 +5,6 @@
         public bool IsInMaintenanceMode { get; set; }
         public bool IsContentFrozen { get; set; }
         public StorageMode StorageMode { get; set; }
-        public int CacheSeconds { get; set; } = 30;
+        public int WaitTimeBetweenDatabaseCalls { get; set; } = 30;
     }
 }

--- a/Our.Umbraco.MaintenanceMode/Configurations/StorageMode.cs
+++ b/Our.Umbraco.MaintenanceMode/Configurations/StorageMode.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.MaintenanceMode.Configurations
+{
+    public enum StorageMode
+    {
+        FileSystem = 0
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/Configurations/StorageMode.cs
+++ b/Our.Umbraco.MaintenanceMode/Configurations/StorageMode.cs
@@ -8,6 +8,7 @@ namespace Our.Umbraco.MaintenanceMode.Configurations
 {
     public enum StorageMode
     {
-        FileSystem = 0
+        FileSystem = 0,
+        Database = 1
     }
 }

--- a/Our.Umbraco.MaintenanceMode/Controllers/MaintenanceModeController.cs
+++ b/Our.Umbraco.MaintenanceMode/Controllers/MaintenanceModeController.cs
@@ -19,7 +19,7 @@ namespace Our.Umbraco.MaintenanceMode.Controllers
         {
 
             Response.StatusCode = 503;
-            return View($"/views/{_maintenanceModeService.Settings.TemplateName}.cshtml", _maintenanceModeService.Settings.ViewModel);
+            return View($"/views/{_maintenanceModeService.Status.Settings.TemplateName}.cshtml", _maintenanceModeService.Status.Settings.ViewModel);
         }
 
         public MaintenanceModeController(IUmbracoContextAccessor umbracoContextAccessor, IUmbracoDatabaseFactory databaseFactory, ServiceContext services, AppCaches appCaches, IProfilingLogger profilingLogger, IPublishedUrlProvider publishedUrlProvider, IMaintenanceModeService maintenanceModeService) 

--- a/Our.Umbraco.MaintenanceMode/Factories/IStorageProviderFactory.cs
+++ b/Our.Umbraco.MaintenanceMode/Factories/IStorageProviderFactory.cs
@@ -1,0 +1,14 @@
+﻿using Our.Umbraco.MaintenanceMode.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.MaintenanceMode.Factories
+{
+    public interface IStorageProviderFactory
+    {
+        IStorageProvider GetProvider();
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/Factories/IStorageProviderFactory.cs
+++ b/Our.Umbraco.MaintenanceMode/Factories/IStorageProviderFactory.cs
@@ -1,4 +1,5 @@
-﻿using Our.Umbraco.MaintenanceMode.Providers;
+﻿using Our.Umbraco.MaintenanceMode.Configurations;
+using Our.Umbraco.MaintenanceMode.Providers;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +10,7 @@ namespace Our.Umbraco.MaintenanceMode.Factories
 {
     public interface IStorageProviderFactory
     {
+        StorageMode StorageMode { get; }
         IStorageProvider GetProvider();
     }
 }

--- a/Our.Umbraco.MaintenanceMode/Factories/StorageProviderFactory.cs
+++ b/Our.Umbraco.MaintenanceMode/Factories/StorageProviderFactory.cs
@@ -1,25 +1,25 @@
-﻿using Microsoft.Extensions.Options;
+﻿using System;
+using Microsoft.Extensions.Options;
 using Our.Umbraco.MaintenanceMode.Configurations;
 using Our.Umbraco.MaintenanceMode.Providers;
-using System;
-using Umbraco.Cms.Core.Configuration.Models;
+using Umbraco.Cms.Core.Sync;
 
 namespace Our.Umbraco.MaintenanceMode.Factories
 {
     public class StorageProviderFactory : IStorageProviderFactory
     {
         private readonly Configurations.MaintenanceModeSettings _maintenanceModeSettings;
-        private readonly IOptions<GlobalSettings> _globalSettings;
         private readonly IServiceProvider _serviceProvider;
+        private readonly IServerRoleAccessor _serverRoleAccessor;
 
         public StorageProviderFactory(
             IOptions<Configurations.MaintenanceModeSettings> maintenanceModeSettings,
-            IOptions<GlobalSettings> globalSettings,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            IServerRoleAccessor serverRoleAccessor)
         {
             _maintenanceModeSettings = maintenanceModeSettings.Value;
-            _serviceProvider = serviceProvider; 
-            _globalSettings = globalSettings;
+            _serviceProvider = serviceProvider;
+            _serverRoleAccessor = serverRoleAccessor;
         }
 
         //public StorageMode StorageMode => this._maintenanceModeSettings?.StorageMode ?? StorageMode.FileSystem;
@@ -27,21 +27,12 @@ namespace Our.Umbraco.MaintenanceMode.Factories
         {
             get
             {
-                if (_maintenanceModeSettings?.StorageMode is not null)
+                return _maintenanceModeSettings?.StorageMode ?? _serverRoleAccessor.CurrentServerRole switch
                 {
-                    // if it's been explicitly set in config
-                    // this is particularly useful for testing (!)
-                    return _maintenanceModeSettings.StorageMode;
-                }
-                else if (_globalSettings.Value.MainDomLock is not "MainDomSemaphoreLock") 
-                {
-                    // otherwise detect whether Umbraco is running in a distributed environment, if so we can't rely on file system/application scope
-                    // by default Umbraco runs under the semaphore lock
-                    // see https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/load-balancing/azure-web-apps#host-synchronization
-                    return StorageMode.Database;
-                }
-                
-                return StorageMode.FileSystem;
+                    // check server role to see if umbraco thinks it's load balanced
+                    ServerRole.Subscriber or ServerRole.SchedulingPublisher => StorageMode.Database,
+                    _ => StorageMode.FileSystem,
+                };
             }
         }
 

--- a/Our.Umbraco.MaintenanceMode/Factories/StorageProviderFactory.cs
+++ b/Our.Umbraco.MaintenanceMode/Factories/StorageProviderFactory.cs
@@ -1,32 +1,53 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
+﻿using Microsoft.Extensions.Options;
 using Our.Umbraco.MaintenanceMode.Configurations;
 using Our.Umbraco.MaintenanceMode.Providers;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Umbraco.Cms.Core.Configuration.Models;
 
 namespace Our.Umbraco.MaintenanceMode.Factories
 {
     public class StorageProviderFactory : IStorageProviderFactory
     {
         private readonly Configurations.MaintenanceModeSettings _maintenanceModeSettings;
-
+        private readonly IOptions<GlobalSettings> _globalSettings;
         private readonly IServiceProvider _serviceProvider;
 
-        public StorageProviderFactory(IOptions<Configurations.MaintenanceModeSettings> maintenanceModeSettings,
+        public StorageProviderFactory(
+            IOptions<Configurations.MaintenanceModeSettings> maintenanceModeSettings,
+            IOptions<GlobalSettings> globalSettings,
             IServiceProvider serviceProvider)
         {
             _maintenanceModeSettings = maintenanceModeSettings.Value;
-            _serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider; 
+            _globalSettings = globalSettings;
         }
 
-        public StorageMode StorageMode => this._maintenanceModeSettings?.StorageMode ?? StorageMode.FileSystem;
+        //public StorageMode StorageMode => this._maintenanceModeSettings?.StorageMode ?? StorageMode.FileSystem;
+        public StorageMode StorageMode
+        {
+            get
+            {
+                if (_maintenanceModeSettings?.StorageMode is not null)
+                {
+                    // if it's been explicitly set in config
+                    // this is particularly useful for testing (!)
+                    return _maintenanceModeSettings.StorageMode;
+                }
+                else if (_globalSettings.Value.MainDomLock is not "MainDomSemaphoreLock") 
+                {
+                    // otherwise detect whether Umbraco is running in a distributed environment, if so we can't rely on file system/application scope
+                    // by default Umbraco runs under the semaphore lock
+                    // see https://docs.umbraco.com/umbraco-cms/fundamentals/setup/server-setup/load-balancing/azure-web-apps#host-synchronization
+                    return StorageMode.Database;
+                }
+                
+                return StorageMode.FileSystem;
+            }
+        }
 
         public IStorageProvider GetProvider() => StorageMode switch
         {
+            StorageMode.Database => (IStorageProvider)_serviceProvider.GetService(typeof(DatabaseStorageProvider)),
             _ => (IStorageProvider)_serviceProvider.GetService(typeof(FileSystemStorageProvider))
         };
     }

--- a/Our.Umbraco.MaintenanceMode/Factories/StorageProviderFactory.cs
+++ b/Our.Umbraco.MaintenanceMode/Factories/StorageProviderFactory.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Our.Umbraco.MaintenanceMode.Configurations;
+using Our.Umbraco.MaintenanceMode.Providers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.MaintenanceMode.Factories
+{
+    public class StorageProviderFactory : IStorageProviderFactory
+    {
+        private readonly Configurations.MaintenanceModeSettings _maintenanceModeSettings;
+
+        private readonly IServiceProvider _serviceProvider;
+
+        public StorageProviderFactory(IOptions<Configurations.MaintenanceModeSettings> maintenanceModeSettings,
+            IServiceProvider serviceProvider)
+        {
+            _maintenanceModeSettings = maintenanceModeSettings.Value;
+            _serviceProvider = serviceProvider;
+        }
+
+        public StorageMode StorageMode => this._maintenanceModeSettings?.StorageMode ?? StorageMode.FileSystem;
+
+        public IStorageProvider GetProvider() => StorageMode switch
+        {
+            _ => (IStorageProvider)_serviceProvider.GetService(typeof(FileSystemStorageProvider))
+        };
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/Interfaces/IMaintenanceModeService.cs
+++ b/Our.Umbraco.MaintenanceMode/Interfaces/IMaintenanceModeService.cs
@@ -7,9 +7,6 @@ namespace Our.Umbraco.MaintenanceMode.Interfaces
     {
         Task ToggleMaintenanceMode(bool maintenanceMode);
         Task ToggleContentFreeze(bool isContentFrozen);
-        bool IsInMaintenanceMode { get; }
-        bool IsContentFrozen { get;  }
-        MaintenanceModeSettings Settings { get; }
         MaintenanceModeStatus Status { get; }
         Task SaveSettings(MaintenanceModeSettings settings);
     }

--- a/Our.Umbraco.MaintenanceMode/MaintenanceMode.cs
+++ b/Our.Umbraco.MaintenanceMode/MaintenanceMode.cs
@@ -12,5 +12,12 @@ namespace Our.Umbraco.MaintenanceMode
         ///  route use for maintenance requests (random name so as not to clash)
         /// </summary>
         public const string MaintenanceRoot = "e7f7581c6bcd4113954e163ff18cbaba";
+
+        public const string PackageAlias = "Our.Umbraco.MaintenanceMode";
+
+        /// <summary>
+        /// Identifier for accessing record in the DB, currently only setting this at global level (-1) is supported 
+        /// </summary>
+        public const int MaintenanceConfigRootId = -1;
     }
 }

--- a/Our.Umbraco.MaintenanceMode/Middleware/MaintenanceRedirectMiddleware.cs
+++ b/Our.Umbraco.MaintenanceMode/Middleware/MaintenanceRedirectMiddleware.cs
@@ -38,10 +38,10 @@ namespace Our.Umbraco.MaintenanceMode.Middleware
             if (backofficeUserAccessor != null)
             {
                 if (_runtimeState.Level == RuntimeLevel.Run &&
-                    _maintenanceModeService.IsInMaintenanceMode)
+                    _maintenanceModeService.Status.IsInMaintenanceMode)
                 {
                     // todo figure out how to do this check here
-                    if (!_maintenanceModeService.Settings.AllowBackOfficeUsersThrough
+                    if (!_maintenanceModeService.Status.Settings.AllowBackOfficeUsersThrough
                         && IsAuthenticated)
                     {
                         context = HandleRequest(context);
@@ -54,8 +54,6 @@ namespace Our.Umbraco.MaintenanceMode.Middleware
             }
 
             await _next(context);
-
-
         }
 
         private bool IsBackOfficeAuthenticated(IBackofficeUserAccessor backofficeUserAccessor) {

--- a/Our.Umbraco.MaintenanceMode/Migrations/InitialMigration.cs
+++ b/Our.Umbraco.MaintenanceMode/Migrations/InitialMigration.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Options;
+using Our.Umbraco.MaintenanceMode.Configurations;
+using Our.Umbraco.MaintenanceMode.Models.Schema;
+using Umbraco.Cms.Infrastructure.Migrations;
+
+namespace Our.Umbraco.MaintenanceMode.Migrations
+{
+    public sealed class InitialMigration : MigrationBase
+    {
+        public const string Key = "maintenance-mode-init";
+
+        private readonly MaintenanceModeSettings _maintenanceModeSettings;
+
+        public InitialMigration(
+            IMigrationContext context,
+            IOptions<MaintenanceModeSettings> maintenanceModeSettings
+        ) : base(context) 
+        {
+        }
+
+        protected override void Migrate()
+        {
+            if (!TableExists(nameof(MaintenanceModeSchema)))
+            {
+                Create.Table<MaintenanceModeSchema>().Do();
+            }
+        }
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/Models/Schema/MaintenanceModeSchema.cs
+++ b/Our.Umbraco.MaintenanceMode/Models/Schema/MaintenanceModeSchema.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using NPoco;
+using Umbraco.Cms.Infrastructure.Persistence.DatabaseAnnotations;
+
+namespace Our.Umbraco.MaintenanceMode.Models.Schema
+{
+    [TableName(TableName)]
+    [PrimaryKey(nameof(Id), AutoIncrement = false)] 
+    [ExplicitColumns]
+    public class MaintenanceModeSchema
+    {
+        public const string TableName = "MaintenanceModeConfig";
+
+        [Column(nameof(Id))]
+        [PrimaryKeyColumn(AutoIncrement = false)]
+        public int Id { get; set; }
+
+        [Column(nameof(Value))]
+        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        public string Value { get; set; }
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Application/UmbracoApplicationStartingHandler.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Application/UmbracoApplicationStartingHandler.cs
@@ -1,0 +1,45 @@
+﻿using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Core.Migrations;
+using Umbraco.Cms.Core.Notifications;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Infrastructure.Migrations.Upgrade;
+using Umbraco.Cms.Infrastructure.Migrations;
+using Our.Umbraco.MaintenanceMode.Migrations;
+using Umbraco.Cms.Infrastructure.Scoping;
+
+namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Application
+{
+    public class UmbracoApplicationStartingHandler : INotificationHandler<UmbracoApplicationStartingNotification>
+    {
+        private readonly IScopeProvider _scopeProvider;
+        private readonly IMigrationPlanExecutor _migrationPlanExecutor;
+        private readonly IKeyValueService _keyValueService;
+        private readonly IRuntimeState _runtimeState;
+
+        public UmbracoApplicationStartingHandler(IScopeProvider scopeProvider,
+            IMigrationPlanExecutor migrationPlanExecutor,
+            IKeyValueService keyValueService,
+            IRuntimeState runtimeState)
+        {
+            _scopeProvider = scopeProvider;
+            _migrationPlanExecutor = migrationPlanExecutor;
+            _keyValueService = keyValueService;
+            _runtimeState = runtimeState;
+        }
+
+        public void Handle(UmbracoApplicationStartingNotification notification)
+        {
+            if (_runtimeState.Level < RuntimeLevel.Run) return;
+
+            var plan = new MigrationPlan(MaintenanceMode.PackageAlias);
+
+            plan.From(string.Empty)
+                .To<InitialMigration>(InitialMigration.Key);
+
+            var upgrader = new Upgrader(plan);
+
+            upgrader.Execute(_migrationPlanExecutor, _scopeProvider, _keyValueService);
+        }
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentCopyingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentCopyingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentCopyingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentDeletingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentDeletingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentDeletingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentMovingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsInMaintenanceMode)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingNotification.cs
@@ -17,7 +17,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentMovingNotification notification)
         {
-            if (_maintenanceModeService.Status.IsInMaintenanceMode)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingToRecycleBinNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingToRecycleBinNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentMovingToRecycleBinNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsInMaintenanceMode)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingToRecycleBinNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingToRecycleBinNotification.cs
@@ -17,7 +17,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentMovingToRecycleBinNotification notification)
         {
-            if (_maintenanceModeService.Status.IsInMaintenanceMode)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentPublishingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentPublishingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentPublishingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentSavingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentSavingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentSavingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentUnpublishingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentUnpublishingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
 
         public void Handle(ContentUnpublishingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaDeletingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaDeletingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Media
 
         public void Handle(MediaDeletingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaMovingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaMovingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Media
 
         public void Handle(MediaMovingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaMovingToRecycleBinNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaMovingToRecycleBinNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Media
 
         public void Handle(MediaMovingToRecycleBinNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaSavingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaSavingNotification.cs
@@ -17,11 +17,11 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Media
 
         public void Handle(MediaSavingNotification notification)
         {
-            if (_maintenanceModeService.IsContentFrozen)
+            if (_maintenanceModeService.Status.IsContentFrozen)
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/Notifications/MaintenanceModeSavedNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/Notifications/MaintenanceModeSavedNotification.cs
@@ -1,0 +1,17 @@
+﻿using Our.Umbraco.MaintenanceMode.Models;
+using Umbraco.Cms.Core.Notifications;
+
+namespace Our.Umbraco.MaintenanceMode.Notifications
+{
+    public sealed class MaintenanceModeSavedNotification : INotification
+    {
+        public bool IsInMaintenanceMode { get; }
+        public bool IsContentFrozen { get; }
+
+        public MaintenanceModeSavedNotification(MaintenanceModeStatus status)
+        {
+            IsInMaintenanceMode = status.IsInMaintenanceMode;
+            IsContentFrozen = status.IsContentFrozen;
+        }
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/Providers/DatabaseStorageProvider.cs
+++ b/Our.Umbraco.MaintenanceMode/Providers/DatabaseStorageProvider.cs
@@ -32,7 +32,7 @@ namespace Our.Umbraco.MaintenanceMode.Providers
             _logger = logger;
             _eventAggregator = eventAggregator;
             _scopeProvider = scope;
-            _timeBetweenChecks = TimeSpan.FromSeconds(_maintenanceModeSettings.CacheSeconds);
+            _timeBetweenChecks = TimeSpan.FromSeconds(_maintenanceModeSettings.WaitTimeBetweenDatabaseCalls);
         }
 
         public async Task<MaintenanceModeStatus> Read()

--- a/Our.Umbraco.MaintenanceMode/Providers/DatabaseStorageProvider.cs
+++ b/Our.Umbraco.MaintenanceMode/Providers/DatabaseStorageProvider.cs
@@ -39,6 +39,13 @@ namespace Our.Umbraco.MaintenanceMode.Providers
                 using var scope = _scopeProvider.CreateScope();
 
                 var db = scope.Database;
+
+                //check for table reduces log warnings
+                if (!scope.SqlContext.SqlSyntax.DoesTableExist(db, MaintenanceModeSchema.TableName))
+                {
+                    return null;
+                }
+
                 var dbStatus = await db.QueryAsync<MaintenanceModeSchema>()
                                        .Where(x => x.Id == MaintenanceMode.MaintenanceConfigRootId)
                                        .FirstOrDefault();

--- a/Our.Umbraco.MaintenanceMode/Providers/DatabaseStorageProvider.cs
+++ b/Our.Umbraco.MaintenanceMode/Providers/DatabaseStorageProvider.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.Extensions.Options;
+using Our.Umbraco.MaintenanceMode.Models;
+using Our.Umbraco.MaintenanceMode.Models.Schema;
+using Serilog;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core.Events;
+using Umbraco.Cms.Infrastructure.Scoping;
+
+namespace Our.Umbraco.MaintenanceMode.Providers
+{
+    public class DatabaseStorageProvider : IStorageProvider
+    {
+        private readonly Configurations.MaintenanceModeSettings _maintenanceModeSettings;
+
+        private readonly ILogger _logger;
+        private readonly IEventAggregator _eventAggregator;
+        private readonly IScopeProvider _scopeProvider;
+
+        public DatabaseStorageProvider(
+            ILogger logger,
+            IOptions<Configurations.MaintenanceModeSettings> maintenanceModeSettings,
+            IEventAggregator eventAggregator,
+            IScopeProvider scope)
+        {
+            _maintenanceModeSettings = maintenanceModeSettings.Value;
+            _logger = logger;
+            _eventAggregator = eventAggregator;
+            _scopeProvider = scope;
+        }
+
+        public async Task<MaintenanceModeStatus> Read()
+        {
+            try
+            {
+                // read from the database
+                using var scope = _scopeProvider.CreateScope();
+
+                var db = scope.Database;
+                var dbStatus = await db.QueryAsync<MaintenanceModeSchema>()
+                                       .Where(x => x.Id == MaintenanceMode.MaintenanceConfigRootId)
+                                       .FirstOrDefault();
+
+                if (dbStatus is null)
+                {
+                    _logger.Warning("Maintenance mode status table was queried but is empty.");
+                    return null;
+                }
+
+                var status = JsonSerializer.Deserialize<MaintenanceModeStatus>(dbStatus.Value);
+             
+                scope.Complete();
+                
+                return status;
+
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, string.Concat("Failed to load Status ", ex.Message));
+            }
+
+            return null;
+        }
+
+        public async Task Save(MaintenanceModeStatus status)
+        {
+            try
+            {
+                string json = JsonSerializer.Serialize(status);
+
+                using var scope = _scopeProvider.CreateScope();
+                
+                var db = scope.Database;
+
+                var dbStatus = await db.QueryAsync<MaintenanceModeSchema>()
+                                       .Where(x => x.Id == MaintenanceMode.MaintenanceConfigRootId)
+                                       .FirstOrDefault();
+
+                if (dbStatus is null)
+                {
+                    await db.InsertAsync(new MaintenanceModeSchema() {  Id = MaintenanceMode.MaintenanceConfigRootId, Value = json });
+                }
+                else
+                {
+                    dbStatus.Value = json;
+                    await db.UpdateAsync(dbStatus);
+                }
+
+                scope.Complete();
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, string.Concat("Failed to save config ", ex.Message));
+            }
+        }
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/Providers/DatabaseStorageProvider.cs
+++ b/Our.Umbraco.MaintenanceMode/Providers/DatabaseStorageProvider.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Options;
 using Our.Umbraco.MaintenanceMode.Models;
 using Our.Umbraco.MaintenanceMode.Models.Schema;
+using Our.Umbraco.MaintenanceMode.Notifications;
 using Serilog;
 using System;
 using System.Text.Json;
@@ -88,6 +89,8 @@ namespace Our.Umbraco.MaintenanceMode.Providers
                 }
 
                 scope.Complete();
+
+                _eventAggregator.Publish(new MaintenanceModeSavedNotification(status));
             }
             catch (Exception ex)
             {

--- a/Our.Umbraco.MaintenanceMode/Providers/FileSystemStorageProvider.cs
+++ b/Our.Umbraco.MaintenanceMode/Providers/FileSystemStorageProvider.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Options;
+using Our.Umbraco.MaintenanceMode.Models;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Extensions;
+
+namespace Our.Umbraco.MaintenanceMode.Providers
+{
+    public class FileSystemStorageProvider : IStorageProvider
+    {
+        private readonly string _configFilePath;
+
+        private readonly Configurations.MaintenanceModeSettings _maintenanceModeSettings;
+
+        private readonly ILogger _logger;
+
+        public FileSystemStorageProvider(
+            ILogger logger,
+            IOptions<Configurations.MaintenanceModeSettings> maintenanceModeSettings,
+            IWebHostEnvironment webHostingEnvironment)
+        {
+            _maintenanceModeSettings = maintenanceModeSettings.Value;
+
+            // put maintenanceMode config in the 'config folder'
+            var configFolder = new DirectoryInfo(webHostingEnvironment.MapPathContentRoot(Constants.SystemDirectories.Config));
+            _configFilePath = Path.Combine(configFolder.FullName, "maintenanceMode.json");
+        }
+
+        public async Task<MaintenanceModeStatus> Read()
+        {
+            if (_configFilePath != null && File.Exists(_configFilePath))
+            {
+                // load from config
+                try
+                {
+                    var file = await File.ReadAllBytesAsync(_configFilePath);
+                    var status = JsonSerializer.Deserialize<MaintenanceModeStatus>(file);
+                    if (status != null)
+                    {
+                        return status;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning(ex, string.Concat("Failed to load Status ", ex.Message));
+                }
+            }
+
+            return null;
+        }
+
+        public async Task Save(MaintenanceModeStatus status)
+        {
+            try
+            {
+                if (File.Exists(_configFilePath))
+                    File.Delete(_configFilePath);
+
+                Directory.CreateDirectory(Path.GetDirectoryName(_configFilePath));
+
+                string json = JsonSerializer.Serialize(status);
+                await File.WriteAllTextAsync(_configFilePath, json);
+            }
+            catch (Exception ex)
+            {
+                _logger.Debug(ex, string.Concat("Failed to save config ", ex.Message));
+            }
+        }
+    }
+}

--- a/Our.Umbraco.MaintenanceMode/Providers/IStorageProvider.cs
+++ b/Our.Umbraco.MaintenanceMode/Providers/IStorageProvider.cs
@@ -1,0 +1,11 @@
+﻿using Our.Umbraco.MaintenanceMode.Models;
+using System.Threading.Tasks;
+
+namespace Our.Umbraco.MaintenanceMode.Providers
+{
+    public interface IStorageProvider
+    {
+        Task Save(MaintenanceModeStatus status);
+        Task<MaintenanceModeStatus> Read();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -3,5 +3,14 @@ Put Umbraco Into Maintenance Mode - While you do things
 
 Simple dashboard to allow you to flick your Umbraco site in and out of Maintenance Mode. 
 
+## Load balanced environments
 
+`Our.Umbraco.MaintenanceMode` supports single web instances immediately after installing. However, when deploying in a load balanced environment additional configuration is required. 
 
+```json
+  "MaintenanceMode": {
+    "StorageMode": "Database"
+  }
+```
+
+This will persist the maintenance mode configuration settings to your Umbraco database and read from there in your content delivery instances. 


### PR DESCRIPTION
Resolves #33 

## Summary
This PR adds support for load balanced environments. It proposes the introduction of a few ideas: 
* An `IStorageProvider` in the service code to access the appropriate place to read/write settings
* An implementation of it - `DatabaseStorageProvider` for use in load balanced setups
* A custom notification to broadcast when settings change (useful for clearing cache or sending emails)

## Testing
How to test?
Add the following to appsettings: 
```json
  "MaintenanceMode": {
    "StorageMode": "Database"
  }
```
This will trigger the switch into database storage mode, observe that settings are written to and read from the database. 

Note that without the app setting above, the code will attempt to determine whether Umbraco is in a load balanced setup and behave accordingly. 

Also @KevinJump sorry it looks like a lot of files changed but there are a lot of one-liners in the notification handlers :)