### PR TITLE
V10 Fix for unfrozen user ids

### DIFF
--- a/Our.Umbraco.MaintenanceMode/Models/MaintenanceModeSettings.cs
+++ b/Our.Umbraco.MaintenanceMode/Models/MaintenanceModeSettings.cs
@@ -1,5 +1,7 @@
 ﻿using Newtonsoft.Json.Serialization;
 using Newtonsoft.Json;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Our.Umbraco.MaintenanceMode.Models
 {
@@ -13,6 +15,19 @@ namespace Our.Umbraco.MaintenanceMode.Models
         ///  users who can get past the content freeze 
         /// </summary>
         public string UnfrozenUsers { get; set; } = "";
+
+        public List<string> UnfrozenUsersList
+        {
+            get
+            {
+                return UnfrozenUsers?.Split(',')
+                                     .Select(s => s.Trim())
+                                     .Where(s => !string.IsNullOrEmpty(s))
+                                     .Distinct()
+                                     .ToList() ?? new List<string>();
+            }
+        }
+
         public MaintenanceMode ViewModel { get; set; }
     }
 }

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentDeletingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentDeletingNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingToRecycleBinNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentMovingToRecycleBinNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentPublishingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentPublishingNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentSavingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentSavingNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentUnpublishingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Content/FreezeContentUnpublishingNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Content
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaDeletingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaDeletingNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Media
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaMovingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaMovingNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Media
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaMovingToRecycleBinNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaMovingToRecycleBinNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Media
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));

--- a/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaSavingNotification.cs
+++ b/Our.Umbraco.MaintenanceMode/NotificationHandlers/Media/FreezeMediaSavingNotification.cs
@@ -21,7 +21,7 @@ namespace Our.Umbraco.MaintenanceMode.NotificationHandlers.Media
             {
                 if (_backofficeUserAccessor.BackofficeUser == null) return;
 
-                if (_maintenanceModeService.Status.Settings.UnfrozenUsers.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
+                if (_maintenanceModeService.Status.Settings.UnfrozenUsersList.Contains(_backofficeUserAccessor.BackofficeUser.GetId().ToString())) return;
 
 
                 notification.CancelOperation(new EventMessage("Warning", "This site is currently frozen during updates", EventMessageType.Error));


### PR DESCRIPTION
Resolves #49 

### Summary
Fix to ensure only user ids that are set are unfrozen when maintenance mode is active. 

### Issue:
Previously, if an ID like "12" was entered, the system would incorrectly unfreeze users with IDs "1", "2", and "12" (matching partial IDs). This behaviour was unintended and could result in unfrozen users who were not targeted.

### Fix:
With this update, only the exact user ID (e.g. "12") is unfrozen, ensuring that only the intended user is affected, and no partial ID matches occur. This change aligns with the expected behaviour when specifying user IDs.