### PR TITLE
Updating dashboard label to be consistent with other dashboard labels

### DIFF
--- a/Our.Umbraco.MaintenanceMode.Client/maintenance-client/src/dashboards/manifest.ts
+++ b/Our.Umbraco.MaintenanceMode.Client/maintenance-client/src/dashboards/manifest.ts
@@ -7,7 +7,7 @@ const dashboards: Array<UmbExtensionManifest> = [
         weight: -10,
         js: ()=>import('./dashboard.element'),
         meta: {
-            label: 'MaintenanceManager',
+            label: 'Maintenance Manager',
             pathname: 'maintenancemanager'
         },
         conditions: [


### PR DESCRIPTION
@KevinJump 

Small change to update the dashboard label from `MaintenanceManager` to `Maintenance Manager`. This makes it more consistent with the OOTB Umbraco dashboard labels:

<img width="595" height="72" alt="dashboard-label" src="https://github.com/user-attachments/assets/6b39585c-9359-4d88-9f38-f0cc37b9f0dc" />
