### PR TITLE
Build Core and Client projects explicitly in CI workflows

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -18,6 +18,8 @@ concurrency:
 
 env:
   config: Release
+  core_project: ./Our.Umbraco.MaintenanceMode.Core/Our.Umbraco.MaintenanceMode.Core.csproj
+  client_project: ./Our.Umbraco.MaintenanceMode.Client/Our.Umbraco.MaintenanceMode.Client.csproj
   package_project: ./Our.Umbraco.MaintenanceMode/Our.Umbraco.MaintenanceMode.csproj
   client_folder: ./Our.Umbraco.MaintenanceMode.Client/maintenance-client
 
@@ -49,6 +51,27 @@ jobs:
       - name: build client
         run: npm run build
         working-directory: ${{ env.client_folder }}
+
+      # Core and Client are built explicitly, not just pulled in transitively via the
+      # package project's ProjectReferences, so a break in either is attributed to the
+      # right project and isn't masked by only ever building the package project.
+      - name: restore core
+        run: dotnet restore ${{ env.core_project }} --locked-mode
+
+      - name: build core
+        run: >
+          dotnet build ${{ env.core_project }}
+          -c ${{ env.config }} --no-restore
+          -p:ContinuousIntegrationBuild=true
+
+      - name: restore client
+        run: dotnet restore ${{ env.client_project }} --locked-mode
+
+      - name: build client project
+        run: >
+          dotnet build ${{ env.client_project }}
+          -c ${{ env.config }} --no-restore
+          -p:ContinuousIntegrationBuild=true
 
       - name: restore
         run: dotnet restore ${{ env.package_project }} --locked-mode

--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -17,6 +17,8 @@ concurrency:
 env:
   config: Release
   out_folder: ./build-out/
+  core_project: ./Our.Umbraco.MaintenanceMode.Core/Our.Umbraco.MaintenanceMode.Core.csproj
+  client_project: ./Our.Umbraco.MaintenanceMode.Client/Our.Umbraco.MaintenanceMode.Client.csproj
   package_project: ./Our.Umbraco.MaintenanceMode/Our.Umbraco.MaintenanceMode.csproj
   client_folder: ./Our.Umbraco.MaintenanceMode.Client/maintenance-client
 
@@ -81,6 +83,27 @@ jobs:
       - name: build client
         run: npm run build
         working-directory: ${{ env.client_folder }}
+
+      # Core and Client are built explicitly, not just pulled in transitively via the
+      # package project's ProjectReferences, so a break in either is attributed to the
+      # right project and isn't masked by only ever building the package project.
+      - name: restore core
+        run: dotnet restore ${{ env.core_project }} --locked-mode
+
+      - name: build core
+        run: >
+          dotnet build ${{ env.core_project }}
+          -c ${{ env.config }} --no-restore
+          -p:ContinuousIntegrationBuild=true
+
+      - name: restore client
+        run: dotnet restore ${{ env.client_project }} --locked-mode
+
+      - name: build client project
+        run: >
+          dotnet build ${{ env.client_project }}
+          -c ${{ env.config }} --no-restore
+          -p:ContinuousIntegrationBuild=true
 
       - name: restore
         run: dotnet restore ${{ env.package_project }} --locked-mode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ concurrency:
 env:
   config: Release
   out_folder: ./build-out/
+  core_project: ./Our.Umbraco.MaintenanceMode.Core/Our.Umbraco.MaintenanceMode.Core.csproj
+  client_project: ./Our.Umbraco.MaintenanceMode.Client/Our.Umbraco.MaintenanceMode.Client.csproj
   package_project: ./Our.Umbraco.MaintenanceMode/Our.Umbraco.MaintenanceMode.csproj
   client_folder: ./Our.Umbraco.MaintenanceMode.Client/maintenance-client
   nuget_source: https://api.nuget.org/v3/index.json
@@ -100,6 +102,27 @@ jobs:
       - name: build client
         run: npm run build
         working-directory: ${{ env.client_folder }}
+
+      # Core and Client are built explicitly, not just pulled in transitively via the
+      # package project's ProjectReferences, so a break in either is attributed to the
+      # right project and isn't masked by only ever building the package project.
+      - name: restore core
+        run: dotnet restore ${{ env.core_project }} --locked-mode
+
+      - name: build core
+        run: >
+          dotnet build ${{ env.core_project }}
+          -c ${{ env.config }} --no-restore
+          -p:ContinuousIntegrationBuild=true
+
+      - name: restore client
+        run: dotnet restore ${{ env.client_project }} --locked-mode
+
+      - name: build client project
+        run: >
+          dotnet build ${{ env.client_project }}
+          -c ${{ env.config }} --no-restore
+          -p:ContinuousIntegrationBuild=true
 
       - name: restore
         run: dotnet restore ${{ env.package_project }} --locked-mode


### PR DESCRIPTION
## Summary
- `dotnet-build.yml`, `package-build.yml`, and `release.yml` all only ran `dotnet build` on the package project, relying on it to pull in `Our.Umbraco.MaintenanceMode.Core` and `Our.Umbraco.MaintenanceMode.Client` transitively via `ProjectReference`.
- Adds explicit `dotnet restore --locked-mode` + `dotnet build` steps for `Our.Umbraco.MaintenanceMode.Core.csproj` and `Our.Umbraco.MaintenanceMode.Client.csproj` ahead of the existing package-project step in all three workflows, so a build break in either is attributed to the right project in the CI log rather than buried inside the package project's output.

## Test plan
- [x] `dotnet restore`/`dotnet build` for Core and Client standalone locally (Release, `-p:ContinuousIntegrationBuild=true`) - both succeed with only pre-existing warnings
- [ ] CI run on this PR (dotnet-build.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)